### PR TITLE
Replace tether with popper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ tmp/*
 
 # leave folders intact
 !*.gitkeep
+
+# OSX
+\.DS_Store

--- a/modules/init.js
+++ b/modules/init.js
@@ -20,7 +20,7 @@ module.exports = function(done) {
 		'/node_modules/jquery/dist/jquery.min.js',
 		'/node_modules/socket.io-client/dist/socket.io.js',
 		'/node_modules/jquery-jcrop/js/jquery.Jcrop.min.js',
-		'/node_modules/tether/dist/js/tether.min.js',
+		'/node_modules/popper.js/dist/umd/popper.min.js',
 		'/public/img/Jcrop.gif'
 	]
 	

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,12 +260,12 @@
       }
     },
     "bootstrap": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-alpha.6.tgz",
-      "integrity": "sha1-T1TdM6wN6sOyhAe8LffsYIhpycg=",
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
+      "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w==",
       "requires": {
         "jquery": "3.2.1",
-        "tether": "1.4.1"
+        "popper.js": "1.12.9"
       }
     },
     "brace-expansion": {
@@ -2344,6 +2344,11 @@
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.0.tgz",
       "integrity": "sha1-H1cwwYnJSTO4G+2iqy+OKFUmOo8="
     },
+    "popper.js": {
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
+      "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
+    },
     "process": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
@@ -2848,11 +2853,6 @@
         "ambi": "2.5.0",
         "csextends": "1.1.1"
       }
-    },
-    "tether": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.1.tgz",
-      "integrity": "sha512-RQ+DAk1gwcQpc0If2dYeFdWPb1osUnMivXAUcAaLXfwoRtoKr/XdVluxNqx7g+YGRvOuPJY2b036hdpdTV97Pg=="
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "app-root-dir": "^1.0.2",
     "bcrypt": "^1.0.3",
     "body-parser": "^1.18.2",
-    "bootstrap": "^4.0.0-alpha.6",
+    "bootstrap": "4.0.0-beta.2",
     "config": "^1.28.0",
     "connect-flash": "^0.1.1",
     "connect-mongo": "^2.0.0",
@@ -54,11 +54,11 @@
     "passport-google-oauth2": "^0.1.6",
     "passport-linkedin-oauth2": "^1.5.0",
     "passport-local": "^1.0.0",
+    "popper.js": "1.12.9",
     "sanitizer": "^0.1.3",
     "sendpulse-api": "^1.0.2",
     "serve-favicon": "^2.4.5",
     "socket.io": "^2.0.4",
-    "tether": "^1.4.1",
     "validator": "^9.1.1",
     "winston": "^2.4.0"
   }

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -16,7 +16,7 @@
 	<link rel="stylesheet" href="/css/style.css"/>
 	
 	<script src="/ext/jquery.min.js"></script>
-	<script src="/ext/tether.min.js"></script>
+	<script src="/ext/popper.min.js"></script>
 	<script src="/ext/bootstrap.min.js"></script>
 	
 </head>


### PR DESCRIPTION
Bootstrap 4.0.0-beta.2 has replaced Tether with Popper.  This missing dependency was causing the app to crash for me on a fresh clone & install.

![screenshot2061](https://user-images.githubusercontent.com/12876929/34171308-7f0858b2-e4b3-11e7-8aae-350b423411a5.png)
